### PR TITLE
Ignore var docblock for converting to comment

### DIFF
--- a/src/rules.php
+++ b/src/rules.php
@@ -70,4 +70,7 @@ return [
         'import_functions' => null,
     ],
     'nullable_type_declaration_for_default_null_value' => false,
+    'phpdoc_to_comment' => [
+        'ignored_tags' => ['var']
+    ],
 ];


### PR DESCRIPTION
```php
/** @var BankingFile $bankingFile */
```
Gets converted to
```php
/* @var BankingFile $bankingFile */
```

This is a problem when using PHStan, as PHPStan does not recognise the docblock with a single star *, and it's not being used. This stops us from fixing errors in our project, because every time fixer is run, the docblocks are converted.
