### PR TITLE
Run fixer in parallel

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -4,6 +4,7 @@ namespace LenderSpender;
 
 use PhpCsFixer\Config;
 use PhpCsFixer\Finder;
+use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
 
 function styles(Finder $finder, array $rules = []): Config {
     $rules = array_merge(require __DIR__.'/rules.php', $rules);
@@ -11,5 +12,6 @@ function styles(Finder $finder, array $rules = []): Config {
     return (new Config())
         ->setFinder($finder)
         ->setRiskyAllowed(true)
-        ->setRules($rules);
+        ->setRules($rules)
+        ->setParallelConfig(ParallelConfigFactory::detect());
 }


### PR DESCRIPTION
PHP-CS-FIXER can be run in parallel, which greatly increases the speed.
From 78 -> 11 seconds on my macbook m1 pro, using 9 cores.

Reason why I came across this, is because if we merge our Rector & CS fixer workflow, we will run this on 8 cores because of the time it takes. So in that case cs-fixer can usage all those cores as well.